### PR TITLE
Update textual references from "master" to "main" branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: docs
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   docs:

--- a/.github/workflows/grcov.yml
+++ b/.github/workflows/grcov.yml
@@ -3,7 +3,7 @@ name: coverage
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
The default branch for this project will be "main" instead of "master". The Git(Hub) repo has been updated already, but some files have textual references to the old branch name and need to be updated aswell.