### PR TITLE
Make crate `#![no_std]` compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,23 @@ keywords = ["chip-8", "chip8"]
 categories = ["emulators", "parser-implementations"]
 build = "build.rs"
 include = ["src/**/*", "README.md", "LICENSE-*", "COPYRIGHT", "build.rs"]
+resolver = "2"
+
+[features]
+default = [
+    "std",
+]
+std = [
+    "rand/std",
+    "rand/std_rng",
+    "thiserror",
+]
 
 [dependencies]
-thiserror = "1.0.18"
-rand = "0.7.3"
+thiserror = { version = "1.0.30", optional = true }
+rand = { version = "0.8.4", default-features = false }
 
 [dev-dependencies]
-bufrng = "1.0.2"
 version-sync = "0.9"
 skeptic = "0.13"
 proptest = "0.10.0"

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,5 +1,7 @@
 //! Display
 
+use alloc::vec::Vec;
+
 /// Monochrome pixel
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Pixel {
@@ -15,7 +17,7 @@ impl Default for Pixel {
     }
 }
 
-impl std::ops::BitXorAssign for Pixel {
+impl core::ops::BitXorAssign for Pixel {
     fn bitxor_assign(&mut self, rhs: Self) {
         *self = match self {
             Self::Off => match rhs {
@@ -30,8 +32,8 @@ impl std::ops::BitXorAssign for Pixel {
     }
 }
 
-impl std::fmt::Display for Pixel {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for Pixel {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             Self::Off => write!(f, "░"),
             Self::On => write!(f, "▓"),
@@ -180,8 +182,8 @@ impl From<u8> for SpriteRow {
     }
 }
 
-impl std::fmt::Display for SpriteRow {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for SpriteRow {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         for pixel in &self.0 {
             write!(f, "{}", pixel)?;
         }
@@ -207,8 +209,8 @@ impl From<&[u8]> for Sprite {
     }
 }
 
-impl std::fmt::Display for Sprite {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for Sprite {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         for row in &self.rows {
             writeln!(f, "{}", row)?;
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,30 +1,32 @@
 //! Crate error types
 
+#[cfg(feature = "std")]
 use thiserror::Error;
 
 /// Error type for all errors in this crate
-#[derive(Error, Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "std", derive(Error))]
 pub enum Chip8Error {
     /// Invalid register definition
-    #[error("invalid register {0:?}")]
+    #[cfg_attr(feature = "std", error("invalid register {0:?}"))]
     InvalidRegister(u8),
 
     /// Unknown instruction
-    #[error("unknown instruction {0:?}")]
+    #[cfg_attr(feature = "std", error("unknown instruction {0:?}"))]
     UnknownInstruction(u16),
 
     /// Known but unimplemented instruction
-    #[error("unimplemented instruction {0:?}")]
+    #[cfg_attr(feature = "std", error("unimplemented instruction {0:?}"))]
     UnimplementedInstruction(crate::instructions::Instruction),
 
     /// Invalid key definition
-    #[error("invalid key {0:?}")]
+    #[cfg_attr(feature = "std", error("invalid key {0:?}"))]
     InvalidKey(u8),
 
     /// Value is out of valid range
-    #[error("out of range {0:?}")]
+    #[cfg_attr(feature = "std", error("out of range {0:?}"))]
     OutOfRange(u16),
 }
 
 /// Result alias
-pub type Result<T> = std::result::Result<T, Chip8Error>;
+pub type Result<T> = core::result::Result<T, Chip8Error>;

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -1,7 +1,7 @@
 //! Machine language and byte code instructions
 
 use crate::errors::Chip8Error;
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 
 /// General purpose register
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -113,7 +113,7 @@ impl Iterator for VRegisterRangeIter {
 
 impl VRegister {
     /// Returns an `Iterator` from `V0` up to including `upper_bound`
-    // NOTE: This could be implemented much nicer with `std::iter::Step`
+    // NOTE: This could be implemented much nicer with `core::iter::Step`
     pub fn iter_to(upper_bound: VRegister) -> impl Iterator<Item = VRegister> {
         VRegisterRangeIter {
             next: Some(Self::V0),

--- a/src/keypad.rs
+++ b/src/keypad.rs
@@ -1,8 +1,8 @@
 //! Keys and keypad
 
 use crate::errors::Chip8Error;
-use std::convert::TryFrom;
-use std::ops::{Index, IndexMut};
+use core::convert::TryFrom;
+use core::ops::{Index, IndexMut};
 
 /// Possible state for each key
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,12 @@
 //! Virtual machine for the CHIP-8 programming language
 
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![doc(html_root_url = "https://docs.rs/chip_8/0.2.0")]
 #![warn(missing_docs)]
 #![forbid(unsafe_code)]
+
+#[macro_use]
+extern crate alloc;
 
 pub mod display;
 pub mod errors;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -286,6 +286,11 @@ mod tests {
     use crate::instructions::{Instruction::*, VRegister::*};
     use crate::keypad::{Key::*, KeyState::*};
 
+    fn test_vm_default() -> VM<rand::rngs::mock::StepRng> {
+        let rng = rand::rngs::mock::StepRng::new(4, 0);
+        VM::new(rng, |_, _| Ok(()))
+    }
+
     #[test]
     fn vregisters_set_get() {
         let mut registers = Registers::new();
@@ -307,7 +312,7 @@ mod tests {
         ) => {
             #[test]
             fn $test_name() -> crate::errors::Result<()> {
-                let mut vm = $crate::vm::VM::default();
+                let mut vm = test_vm_default();
                 $(
                   vm.registers[$register_before] = $register_before_value;
                 )+
@@ -339,6 +344,7 @@ mod tests {
         };
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn vm_execute_instruction_sys_default() -> crate::errors::Result<()> {
         let mut vm = VM::default();
@@ -369,7 +375,7 @@ mod tests {
 
     #[test]
     fn vm_execute_instruction_jump() -> crate::errors::Result<()> {
-        let mut vm = VM::default();
+        let mut vm = test_vm_default();
         vm.registers.pc = 0x0;
 
         vm.execute_instruction(&Instruction::Jump(0x0FFF.into()))?;
@@ -380,7 +386,7 @@ mod tests {
 
     #[test]
     fn vm_execute_instruction_skipequaloperand() -> crate::errors::Result<()> {
-        let mut vm = VM::default();
+        let mut vm = test_vm_default();
         vm.registers.pc = 0x0;
         vm.registers[V0] = 0xFF;
 
@@ -392,7 +398,7 @@ mod tests {
 
     #[test]
     fn vm_execute_instruction_skipnotequaloperand() -> crate::errors::Result<()> {
-        let mut vm = VM::default();
+        let mut vm = test_vm_default();
         vm.registers.pc = 0x0;
         vm.registers[V0] = 0xFF;
 
@@ -404,7 +410,7 @@ mod tests {
 
     #[test]
     fn vm_execute_instruction_skipequal() -> crate::errors::Result<()> {
-        let mut vm = VM::default();
+        let mut vm = test_vm_default();
         vm.registers.pc = 0x0;
         vm.registers[V0] = 0xFF;
         vm.registers[VF] = 0xFF;
@@ -588,7 +594,7 @@ mod tests {
 
     #[test]
     fn vm_execute_instruction_skipnotequal() -> crate::errors::Result<()> {
-        let mut vm = VM::default();
+        let mut vm = test_vm_default();
         vm.registers.pc = 0x0;
         vm.registers[V0] = 0xFF;
         vm.registers[VF] = 0xEE;
@@ -601,7 +607,7 @@ mod tests {
 
     #[test]
     fn vm_execute_instruction_loadi() -> crate::errors::Result<()> {
-        let mut vm = VM::default();
+        let mut vm = test_vm_default();
         vm.registers.i = 0xF0F0;
 
         vm.execute_instruction(&LoadI(0x0AAA.into()))?;
@@ -612,7 +618,7 @@ mod tests {
 
     #[test]
     fn vm_execute_instruction_longjump() -> crate::errors::Result<()> {
-        let mut vm = VM::default();
+        let mut vm = test_vm_default();
         vm.registers.pc = 0x0111;
         vm.registers[V0] = 0x11;
 
@@ -624,7 +630,7 @@ mod tests {
 
     #[test]
     fn vm_execute_instruction_skipkeypressed() -> crate::errors::Result<()> {
-        let mut vm = VM::default();
+        let mut vm = test_vm_default();
         vm.registers.pc = 0x0111;
         vm.registers[V6] = 0x4;
         vm.keypad[Key4] = Pressed;
@@ -637,7 +643,7 @@ mod tests {
 
     #[test]
     fn vm_execute_instruction_skipkeynotpressed() -> crate::errors::Result<()> {
-        let mut vm = VM::default();
+        let mut vm = test_vm_default();
         vm.registers.pc = 0x0111;
         vm.registers[V6] = 0x4;
         vm.keypad[Key4] = NotPressed;
@@ -650,7 +656,7 @@ mod tests {
 
     #[test]
     fn vm_execute_instruction_loadkey() -> crate::errors::Result<()> {
-        let mut vm = VM::default();
+        let mut vm = test_vm_default();
         vm.waiting_on_any_keypress = None;
 
         vm.execute_instruction(&LoadKey(V6))?;
@@ -661,7 +667,7 @@ mod tests {
 
     #[test]
     fn vm_execute_instruction_addi() -> crate::errors::Result<()> {
-        let mut vm = VM::default();
+        let mut vm = test_vm_default();
         vm.registers[V0] = 0x1;
         vm.registers.i = 0x0AAA;
 
@@ -685,7 +691,7 @@ mod tests {
 
     #[test]
     fn vm_execute_instruction_draw() -> crate::errors::Result<()> {
-        let mut vm = VM::default();
+        let mut vm = test_vm_default();
         vm.registers[V0] = 0xF;
         vm.registers[V1] = 0x0;
         vm.registers.i = 0x0111;
@@ -704,7 +710,7 @@ mod tests {
 
     #[test]
     fn vm_execute_instruction_loadsprite() -> crate::errors::Result<()> {
-        let mut vm = VM::default();
+        let mut vm = test_vm_default();
         vm.registers[V0] = 0xF;
 
         vm.execute_instruction(&Instruction::LoadSprite(V0))?;
@@ -726,7 +732,7 @@ mod tests {
 
     #[test]
     fn vm_execute_instruction_loadbinarycodeddecimal() -> crate::errors::Result<()> {
-        let mut vm = VM::default();
+        let mut vm = test_vm_default();
         vm.registers[V0] = 123;
         vm.registers.i = 0x0111;
 
@@ -740,7 +746,7 @@ mod tests {
 
     #[test]
     fn vm_execute_instruction_loadmemoryregisters_all() -> crate::errors::Result<()> {
-        let mut vm = VM::default();
+        let mut vm = test_vm_default();
         vm.registers[V0] = 0x0;
         vm.registers[V1] = 0x1;
         vm.registers[V2] = 0x2;
@@ -783,7 +789,7 @@ mod tests {
 
     #[test]
     fn vm_execute_instruction_loadmemoryregisters_one() -> crate::errors::Result<()> {
-        let mut vm = VM::default();
+        let mut vm = test_vm_default();
         vm.registers[V0] = 0xAA;
         vm.registers[V1] = 0xBB;
         vm.registers.i = 0x0111;
@@ -798,7 +804,7 @@ mod tests {
 
     #[test]
     fn vm_execute_instruction_loadregistersmemory_all() -> crate::errors::Result<()> {
-        let mut vm = VM::default();
+        let mut vm = test_vm_default();
         vm.registers.i = 0x0111;
         vm.memory.write((0x0111 + 0x0).into(), 0x0);
         vm.memory.write((0x0111 + 0x1).into(), 0x1);
@@ -841,7 +847,7 @@ mod tests {
 
     #[test]
     fn vm_execute_instruction_loadregistersmemory_one() -> crate::errors::Result<()> {
-        let mut vm = VM::default();
+        let mut vm = test_vm_default();
         vm.registers.i = 0x0111;
         vm.memory.write((0x0111 + 0x0).into(), 0x0);
         vm.memory.write((0x0111 + 0x1).into(), 0x1);

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -4,10 +4,10 @@ use crate::display::{Display, DrawResult, XCoordinate, YCoordinate};
 use crate::instructions::{Addr, Instruction, VRegister};
 use crate::keypad::{Key, KeyState};
 use crate::memory::Memory;
-use rand::Rng;
+use alloc::vec::Vec;
 use core::convert::TryFrom;
 use core::ops::{Index, IndexMut};
-use alloc::vec::Vec;
+use rand::Rng;
 
 /// Type of a general purpose register in the VM
 type VRegisterValue = u8;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -5,8 +5,9 @@ use crate::instructions::{Addr, Instruction, VRegister};
 use crate::keypad::{Key, KeyState};
 use crate::memory::Memory;
 use rand::Rng;
-use std::convert::TryFrom;
-use std::ops::{Index, IndexMut};
+use core::convert::TryFrom;
+use core::ops::{Index, IndexMut};
+use alloc::vec::Vec;
 
 /// Type of a general purpose register in the VM
 type VRegisterValue = u8;
@@ -76,6 +77,7 @@ pub struct VM<R: Rng> {
     display: Display,
 }
 
+#[cfg(feature = "std")]
 impl Default for VM<rand::rngs::ThreadRng> {
     /// Creates a new instance with thread-local random number generator
     #[must_use]
@@ -671,7 +673,7 @@ mod tests {
 
     #[test]
     fn vm_execute_instruction_random() -> crate::errors::Result<()> {
-        let rng = bufrng::BufRng::new(&[0, 0, 0, 0b1000_0000]);
+        let rng = rand::rngs::mock::StepRng::new(0b1000_0000, 0);
         let mut vm = VM::new(rng, |_, _| Ok(()));
         vm.registers[V0] = 0x00;
 


### PR DESCRIPTION
After a bit of trial and error with indirect dependencies and their features, this seems to be working. `bufrng` is not maintained anymore, but not needed either.

This might bump the MSRV, but we didn't make guarantees on that or document it anyways.