### PR TITLE
Add configuration for `cargo release`

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,12 @@
+# configuration for https://crates.io/crates/cargo-release
+
+allow-branch = [ "main" ]
+pre-release-commit-message = "Version {{version}}"
+tag-message = "Version {{version}}"
+dev-version = false
+enable-all-features = true
+pre-release-hook = ["cargo", "test"]
+pre-release-replacements = [
+  { file="README.md", search="chip_8 = \".+\"", replace="chip_8 = \"{{version}}\"", exactly=1 },
+  { file="src/lib.rs", search="#!\\[doc\\(html_root_url = \"https://docs.rs/chip_8/.+\"\\)]", replace="#![doc(html_root_url = \"https://docs.rs/chip_8/{{version}}\")]", exactly=1 }, 
+]


### PR DESCRIPTION
Using `cargo release` should automate most of the otherwise manual tasks:
- Update textual references to new version
- Git tag
- `cargo publish`

Needs to be run with e.g. `cargo release minor`