### PR TITLE
Document crate features for `docs.rs`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,10 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --verbose --no-deps --all-features
+          args: --verbose --lib --no-deps --all-features
+        env:
+          RUSTFLAGS: --cfg docsrs
+          RUSTDOCFLAGS: --cfg docsrs -Dwarnings
 
       - name: finalize docs
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,5 @@ maintenance = { status = "experimental" }
 
 [package.metadata.docs.rs]
 targets = []
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,6 +4,10 @@
 use thiserror::Error;
 
 /// Error type for all errors in this crate
+///
+/// # Features
+///
+/// Feature `std` adds an `impl std::error::Error`.
 #[derive(Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "std", derive(Error))]
 pub enum Chip8Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,25 @@
 //! Virtual machine for the CHIP-8 programming language
+//!
+//! # Features
+//! This crate uses [Cargo "features"](https://doc.rust-lang.org/cargo/reference/features.html#the-features-section) for conditional compilation.
+//! - `std`: Enables usage of [Rust's standard library `std`](https://doc.rust-lang.org/std/)
+//!
+//! Functionality affected by features should have a `rustdoc` hint in this documentation, e.g.:
+//! > This is supported on **crate feature `std`** only.
+//!
+//! If this is not possible for technical reasons there should be a "Features" heading describing the details instead.
+//!
+//! ## Feature `std`
+//! This crate is [`no_std`](https://github.com/rust-lang/rfcs/blob/master/text/1184-stabilize-no_std.md) compatible if you disable this feature.
+//!
+//! This is a [default feature](https://doc.rust-lang.org/cargo/reference/features.html#the-default-feature) and can be disabled with `default-features = false` in your `chip_8` [dependency declaration](https://doc.rust-lang.org/cargo/reference/features.html#dependency-features).
+//!
+//! Even if disabled this crate still requires the [Rust core allocation and collections library `alloc`](https://doc.rust-lang.org/alloc/), i.e. a global allocator.
+//!
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg_hide))]
+#![cfg_attr(docsrs, doc(cfg_hide(docsrs)))]
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![doc(html_root_url = "https://docs.rs/chip_8/0.3.0")]
 #![warn(missing_docs)]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -77,6 +77,7 @@ pub struct VM<R: Rng> {
     display: Display,
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[cfg(feature = "std")]
 impl Default for VM<rand::rngs::ThreadRng> {
     /// Creates a new instance with thread-local random number generator


### PR DESCRIPTION
This adds rustdoc for the crate features and configuration for `docs.rs`.